### PR TITLE
Refactor PostgresMapReader init

### DIFF
--- a/openlr_dereferencer/stl_osm_map/__init__.py
+++ b/openlr_dereferencer/stl_osm_map/__init__.py
@@ -30,7 +30,7 @@ class PostgresMapReader(MapReader):
         self.lines_tbl_name = lines_tbl_name
         self.nodes_tbl_name = nodes_tbl_name
         self.connection = conn
-        self.cursor = self.connection if self.connection else None
+        self.cursor = self.connection.cursor() if self.connection else None
         self.srid = srid
 
     def __enter__(self):

--- a/openlr_dereferencer/stl_osm_map/__init__.py
+++ b/openlr_dereferencer/stl_osm_map/__init__.py
@@ -21,6 +21,7 @@ class PostgresMapReader(MapReader):
         db_schema,
         lines_tbl_name,
         nodes_tbl_name,
+        conn=None,
         srid=4326,
     ):
         self.connect_db = ext_connect_db_method
@@ -28,14 +29,15 @@ class PostgresMapReader(MapReader):
         self.db_schema = db_schema
         self.lines_tbl_name = lines_tbl_name
         self.nodes_tbl_name = nodes_tbl_name
-        self.connection = None
+        self.connection = conn
+        self.cursor = self.connection if self.connection else None
         self.srid = srid
 
     def __enter__(self):
-        assert self.db_nickname is not None
-        self.connection = self.connect_db(
-            nickname=self.db_nickname, driver="psycopg2"
-        )
+        if not self.connection:
+            self.connection = self.connect_db(
+                nickname=self.db_nickname, driver="psycopg2"
+            )
         self.cursor = self.connection.cursor()
         return self
 

--- a/openlr_dereferencer/stl_osm_map/__init__.py
+++ b/openlr_dereferencer/stl_osm_map/__init__.py
@@ -1,5 +1,5 @@
-"""The example map format described in `map_format.md`, conforming to
-the interface in openlr_dereferencer.maps"""
+"""A map reader for postgresql, conforming to
+the interface defined in openlr_dereferencer.maps.abstract"""
 
 from typing import Iterable, Optional
 from openlr import Coordinates
@@ -9,42 +9,31 @@ from openlr_dereferencer.maps import MapReader
 
 class PostgresMapReader(MapReader):
     """
-    This is a reader for the example map format described in `map_format.md`.
-
-    Create an instance with: `ExampleMapReader('example.sqlite')`.
+    This is a reader for the basemap table stored in postgres as two tables of lines and nodes`.
     """
 
     def __init__(
         self,
-        ext_connect_db_method,
-        db_nickname,
         db_schema,
         lines_tbl_name,
         nodes_tbl_name,
-        conn=None,
+        conn,
         srid=4326,
     ):
-        self.connect_db = ext_connect_db_method
-        self.db_nickname = db_nickname
         self.db_schema = db_schema
         self.lines_tbl_name = lines_tbl_name
         self.nodes_tbl_name = nodes_tbl_name
         self.connection = conn
-        self.cursor = self.connection.cursor() if self.connection else None
         self.srid = srid
 
     def __enter__(self):
-        if not self.connection:
-            self.connection = self.connect_db(
-                nickname=self.db_nickname, driver="psycopg2"
-            )
-        self.cursor = self.connection.cursor()
+        self.cursor = self.connection.cursor() if self.connection else None
         return self
 
     def __exit__(self, *exc_info):
-        # make sure the dbconnection gets closed
+        # make sure the cursor gets closed
         try:
-            close_it = self.connection.close
+            close_it = self.cursor.close
         except AttributeError:
             pass
         else:

--- a/openlr_dereferencer/stl_osm_map/__init__.py
+++ b/openlr_dereferencer/stl_osm_map/__init__.py
@@ -9,7 +9,7 @@ from openlr_dereferencer.maps import MapReader
 
 class PostgresMapReader(MapReader):
     """
-    This is a reader for the basemap table stored in postgres as two tables of lines and nodes`.
+    This is a reader for the basemap table stored in postgres as two tables: lines and nodes`.
     """
 
     def __init__(
@@ -24,13 +24,16 @@ class PostgresMapReader(MapReader):
         self.lines_tbl_name = lines_tbl_name
         self.nodes_tbl_name = nodes_tbl_name
         self.connection = conn
+        self.cursor = self.connection.cursor()
         self.srid = srid
 
     def __enter__(self):
-        self.cursor = self.connection.cursor() if self.connection else None
         return self
 
     def __exit__(self, *exc_info):
+        self.close()
+
+    def close(self):
         # make sure the cursor gets closed
         try:
             close_it = self.cursor.close
@@ -38,6 +41,7 @@ class PostgresMapReader(MapReader):
             pass
         else:
             close_it()
+        self.cursor = None
 
     def get_line(self, line_id: int) -> Line:
         # Just verify that this line ID exists.

--- a/openlr_dereferencer/stl_osm_map/__init__.py
+++ b/openlr_dereferencer/stl_osm_map/__init__.py
@@ -15,7 +15,13 @@ class PostgresMapReader(MapReader):
     """
 
     def __init__(
-        self, ext_connect_db_method, db_nickname, db_schema, lines_tbl_name, nodes_tbl_name, srid=4326
+        self,
+        ext_connect_db_method,
+        db_nickname,
+        db_schema,
+        lines_tbl_name,
+        nodes_tbl_name,
+        srid=4326,
     ):
         self.connect_db = ext_connect_db_method
         self.db_nickname = db_nickname


### PR DESCRIPTION
reader obj now requires that an externally defined db conn obj is passed in at initialization. context manager will open and close the connection cursor but the connection itself must be opened/closed outside of the reader.