### PR TITLE
none geom check from bool to is

### DIFF
--- a/openlr_dereferencer/stl_osm_map/primitives.py
+++ b/openlr_dereferencer/stl_osm_map/primitives.py
@@ -108,7 +108,7 @@ class Line(AbstractLine):
     def geometry(self) -> LineString:
         "Returns the line geometry"
         # chg list comp to single call
-        if not self._geometry:
+        if self._geometry is None:
             self.get_and_store_database_info()
         return self._geometry
 


### PR DESCRIPTION
`if not self._geometry:` was triggering a call to shapely.geometry.is_empty()` which was causing a recursion error that was hard to debug and probably not the right way to do what we wanted here anyways, which is to just check if self._geometry is None.